### PR TITLE
dockerfile: add real symlinks

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,4 +2,4 @@ FROM ARG_FROM
 
 MAINTAINER CoreOS Inc. <coreos-dev@googlegroups.com>
 
-COPY bin/ARG_ARCH/ARG_BIN        /
+ADD bin/docker-rootfs-ARG_ARCH.tgz        /

--- a/Makefile
+++ b/Makefile
@@ -93,8 +93,8 @@ DOTFILE_IMAGE = $(subst :,_,$(subst /,_,$(IMAGE))-$(VERSION))
 
 container: .container-$(DOTFILE_IMAGE) container-name
 .container-$(DOTFILE_IMAGE): bin/$(ARCH)/$(BIN) Dockerfile.in
+	@tar -czvf bin/docker-rootfs-$(ARCH).tgz --exclude linux_$(ARCH) -C bin/$(ARCH)/ .
 	@sed \
-	    -e 's|ARG_BIN|torcx-tectonic-*|g' \
 	    -e 's|ARG_ARCH|$(ARCH)|g' \
 	    -e 's|ARG_FROM|$(BASEIMAGE)|g' \
 	    Dockerfile.in > .dockerfile-$(ARCH)


### PR DESCRIPTION
This amends the Dockerfile to use the ADD tgz extraction feature in
order to preserve symlinks. This needs a rootfs to be tar'ed first,
but cuts the container size to 1/3 of the current one.