### PR TITLE
Split Run() in to separate methods for Bootstrap and Hook

### DIFF
--- a/cli/torcx-tectonic-bootstrap.go
+++ b/cli/torcx-tectonic-bootstrap.go
@@ -52,5 +52,5 @@ func runBootstrap(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return app.Run()
+	return app.Bootstrap()
 }

--- a/cli/torcx-tectonic-hook-pre.go
+++ b/cli/torcx-tectonic-hook-pre.go
@@ -62,7 +62,7 @@ func runHookPre(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = app.Run()
+	err = app.UpdateHook()
 	if err != nil {
 		return err
 	}

--- a/internal/kube.go
+++ b/internal/kube.go
@@ -60,15 +60,16 @@ func (a *App) GetKubeVersion() (string, error) {
 	if apiErr == nil {
 		return apiVersion, nil
 	}
-	logrus.Debug("failed attempt to determine Kubernetes APIServer version: ", apiErr)
+	logrus.Warn("failed attempt to determine Kubernetes APIServer version: ", apiErr)
 
-	pathVersion, pathErr := a.versionFromPath(installerEnvPath, envVersionKey)
+	pathVersion, pathErr := versionFromPath(installerEnvPath, envVersionKey)
 	if pathErr == nil {
+		logrus.Warn("Falling back to installer-provided kubernetes version")
 		// This accomodates for charset constraints in docker tags (for the hyperkube image)
 		version := strings.Replace(pathVersion, "_", "+", -1)
 		return version, nil
 	}
-	logrus.Debug("failed attempt to determine Kubernetes installer version: ", pathErr)
+	logrus.Warn("failed attempt to determine Kubernetes installer version: ", pathErr)
 
 	return "", errors.New("unable to determine cluster version")
 }
@@ -96,7 +97,7 @@ func (a *App) versionFromAPIServer() (string, error) {
 }
 
 // versionFromPath reads Kubernetes version from a file
-func (a *App) versionFromPath(path string, envKey string) (string, error) {
+func versionFromPath(path string, envKey string) (string, error) {
 	flags, err := readEnvFile(path)
 	if err != nil {
 		return "", err

--- a/internal/torcx.go
+++ b/internal/torcx.go
@@ -104,7 +104,7 @@ func (a *App) InstallAddon(name string, reference string, osChannel string, osVe
 	}
 
 	// GC
-	err = a.TorcxGC()
+	err = a.TorcxGC(osVersions)
 	if err != nil {
 		logrus.Error("failed to GC old torx stores (continuing): ", err)
 	}
@@ -193,8 +193,8 @@ func (a *App) UseAddon(name string, reference string) error {
 // TorcxGC removes versioned stores that we know we won't need.
 // As a safety mechanism, this won't do anything unless we are keeping at least
 // 2 OS versions.
-func (a *App) TorcxGC() error {
-	if len(a.OSVersions) < 2 {
+func (a *App) TorcxGC(osVersions []string) error {
+	if len(osVersions) < 2 {
 		logrus.Debug("Skipping TorcxGC; need at least 2 active OSVersions")
 		return nil
 	}
@@ -212,7 +212,7 @@ L:
 		if !entry.IsDir() {
 			continue
 		}
-		for _, keep := range a.OSVersions {
+		for _, keep := range osVersions {
 			if entry.Name() == keep {
 				continue L
 			}

--- a/internal/torcx_test.go
+++ b/internal/torcx_test.go
@@ -42,9 +42,9 @@ func TestTorcxGC(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a.OSVersions = []string{"v2", "v3"}
+	OSVersions := []string{"v2", "v3"}
 
-	err = a.TorcxGC()
+	err = a.TorcxGC(OSVersions)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This makes a few changes to the datastructures in anticipation of the separate fallback modes.