### PR TITLE
Misc bugfixes

### DIFF
--- a/internal/kube.go
+++ b/internal/kube.go
@@ -193,6 +193,7 @@ func retry(tries, pause uint, f func() error) error {
 		if err == nil {
 			return nil
 		}
+		tries--
 		time.Sleep(time.Duration(pause) * time.Second)
 	}
 	return err

--- a/internal/package_manifest.go
+++ b/internal/package_manifest.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// StoreTemplate is the URL template for the default ContainerLinux torcx store
-	ManifestURLTemplate = "https://tectonic-torcx.release.core-os.net/{{.Board}}/{{.OSVersion}}/torcx_manifest.json"
+	ManifestURLTemplate = "https://tectonic-torcx.release.core-os.net/manifests/{{.Board}}/{{.OSVersion}}/torcx_manifest.json"
 
 	KIND_PACKAGE_MANIFEST = "torcx-package-list-v0"
 )

--- a/internal/strategy.go
+++ b/internal/strategy.go
@@ -23,7 +23,7 @@ import (
 )
 
 // MinimumRemoteDocker is the first CL bucket with published docker addons
-const MinimumRemoteDocker = "1520.0.0"
+const MinimumRemoteDocker = "1520.2.0"
 
 // This error is returned when there is no suitable package available to install.
 var NoVersionError = errors.New("No suitable version available")


### PR DESCRIPTION
This fixes three bugs:
 * final URL template has been slightly changed
 * first CL version with a store manifest is 1520.2.0
 * an error in retry logic causing infinite loop