### PR TITLE
docker: bump baseimage to torcx:v0.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ PRODTAG := installer-latest
 SRC_DIRS := cli internal pkg
 
 ALL_ARCH := amd64 arm64
-BASEIMAGE?=quay.io/coreos/torcx:v0.1.1
+BASEIMAGE?=quay.io/coreos/torcx:v0.1.2
 
 # Image name ends with the -arch unless it's amd64
 ifeq ($(ARCH),amd64)


### PR DESCRIPTION
This bumps torcx to v0.1.2, which includes a temporary transition mechanism
for ContainerLinux and docker-1.12:
https://github.com/coreos/torcx/releases/tag/v0.1.2