### PR TITLE
versions: update for kubernetes 1.8 and 1.9

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -4,8 +4,13 @@ versions:
     1.6:
         docker: [ "1.12"]
     1.7:
+        # Kubernetes: https://github.com/kubernetes/kubernetes/blob/v1.9.0-alpha.2/CHANGELOG-1.7.md#external-dependency-version-information
+        # Latest CL stable: https://tectonic-torcx.release.core-os.net/manifests/amd64-usr/1520.8.0/torcx_manifest.json
         docker: [ "1.12" ]
     1.8:
-        # As per k8s issue 42926, 1.11, 1.12, 1.13, and 17.03 are supported
-        # see https://github.com/kubernetes/kubernetes/issues/42926#issuecomment-325733231
-        docker: [ "1.13", "1.12"]
+        # Kubernetes: https://github.com/kubernetes/kubernetes/blob/v1.9.0-alpha.2/CHANGELOG-1.8.md#external-dependency-version-information
+        # Latest CL stable: https://tectonic-torcx.release.core-os.net/manifests/amd64-usr/1520.8.0/torcx_manifest.json
+        docker: [ "17.03", "1.12"]
+    1.9:
+        # TODO: forecast only, fix this with actual versions
+        docker: [ "17.03", "1.12"]


### PR DESCRIPTION
This updates runtime version mappings for k8s 1.8 and 1.9.

1.8 is the current upstream stable release; Docker version mapping has
been requested and validated in INST-505.
Note: docker 1.13 has never been shipped in any CL torcx bucket, thus
removing it here.

1.9 is currently in alpha stage; version mapping still needs to be
defined, this is only a conservative forecast as of now.