### PR TITLE
manifest: when ignoring signature, skip fetching it too

### DIFF
--- a/cli/common.go
+++ b/cli/common.go
@@ -61,7 +61,7 @@ func commonFlags(f *pflag.FlagSet) {
 	f.StringVar(&flagTorcxManifestURL, "torcx-manifest-url", internal.ManifestURLTemplate, "URL (template) for torcx package manifest")
 	f.StringVar(&cfg.ProfileName, "torcx-profile", TectonicTorcxProfile, "torcx profile to create, if needed")
 	f.StringVar(&cfg.ForceKubeVersion, "force-kube-version", "", "force a kubernetes version, rather than determining from the apiserver")
-	f.BoolVar(&cfg.NoVerifySig, "no-verify-signatures", false, "don't gpg-verify all downloaded addons")
+	f.BoolVar(&cfg.NoVerifySig, "no-verify-signatures", false, "don't gpg-verify remote assets")
 	f.StringVar(&cfg.GpgKeyringPath, "keyring", "/pubring.gpg", "path to the gpg keyring")
 	f.StringVar(&cfg.VersionManifestPath, "version-manifest", "", "path to the runtime-mappings manifest file")
 	f.StringVar(&verbose, "verbose", "info", "verbosity level")

--- a/internal/fetch.go
+++ b/internal/fetch.go
@@ -67,7 +67,7 @@ func (a *App) FetchAddon(loc *Location) (string, error) {
 	}
 	if !ok {
 		os.Remove(tmpfile.Name())
-		return "", errors.New("Signature validation failed")
+		return "", errors.New("Hash validation failed")
 	}
 
 	return tmpfile.Name(), nil

--- a/internal/package_manifest.go
+++ b/internal/package_manifest.go
@@ -96,7 +96,7 @@ func (a *App) GetPackageManifest(osVersion string) (*PackageManifest, error) {
 		logrus.Warn("signature verification disabled, skipping fetch phase")
 	} else {
 		if err := fetchURL(manifestURL+".asc", &manifestSigB); err != nil {
-			return nil, errors.Wrapf(err, "could not fetch manifest signature at %s.aci", manifestURL)
+			return nil, errors.Wrapf(err, "could not fetch manifest signature at %s.asc", manifestURL)
 		}
 		if err := a.gpgVerify(bytes.NewReader(manifestBuff.Bytes()), &manifestSigB); err != nil {
 			return nil, errors.Wrap(err, "gpg validation failed")


### PR DESCRIPTION
On `--no-verify-signatures=true`, tectonic-torcx would still try to
download the `.asc` detached signature and hard-fail if that is missing.
This changes the behavior to skip the fetching phase too when signature
validation is disabled.

Fixes OST-139