### PR TITLE
update_engine: use `VERSION_ID` from os-release

### DIFF
--- a/internal/update_engine.go
+++ b/internal/update_engine.go
@@ -43,9 +43,9 @@ func GetCurrentOSInfo() (string, string, error) {
 		return "", "", errors.Wrap(err, "could not read os-release file")
 	}
 
-	version := parseOSRelease(string(osr), "VERSION")
+	version := parseOSRelease(string(osr), "VERSION_ID")
 	if version == "" {
-		return "", "", errors.New("invalid os-release file, unable to determine VERSION")
+		return "", "", errors.New("invalid os-release file, unable to determine VERSION_ID")
 	}
 	board := parseOSRelease(string(osr), "COREOS_BOARD")
 	if board == "" {

--- a/internal/update_engine_test.go
+++ b/internal/update_engine_test.go
@@ -24,15 +24,15 @@ func TestParseOSRelease(t *testing.T) {
 	assert := assert.New(t)
 	inp := `NAME="Container Linux by CoreOS"
 ID=coreos
-VERSION=1465.0.0
-VERSION_ID=1465.0.0
-BUILD_ID=2017-07-06-0206
-PRETTY_NAME="Container Linux by CoreOS 1465.0.0 (Ladybug)"
+VERSION=1662.0.0+2018-01-19-1643
+VERSION_ID=1662.0.0
+BUILD_ID=2018-01-19-1643
+PRETTY_NAME="Container Linux by CoreOS 1662.0.0+2018-01-19-1643 (Ladybug)"
 ANSI_COLOR="38;5;75"
 HOME_URL="https://coreos.com/"
 BUG_REPORT_URL="https://issues.coreos.com"
 COREOS_BOARD="amd64-usr"`
 
-	assert.Equal("1465.0.0", parseOSRelease(inp, "VERSION"))
+	assert.Equal("1662.0.0", parseOSRelease(inp, "VERSION_ID"))
 	assert.Equal("amd64-usr", parseOSRelease(inp, "COREOS_BOARD"))
 }


### PR DESCRIPTION
This changes the `/etc/os-release` parsing logic to use `VERSION_ID`
instead of `VERSION`, as recommended for scripts in
https://www.freedesktop.org/software/systemd/man/os-release.html

This is a bugfix to prevent a further cascade of failures on nightly CL
builds, where `VERSION` also contains build timestamp.

Fixes #OST-140